### PR TITLE
Discussion: Block all discussion prefixes from being crawled

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -20,6 +20,7 @@ Disallow: /discussion/your-profile
 Disallow: /discussion/your-comments
 Disallow: /discussion/edit-profile
 Disallow: /discussion/search/comments
+Disallow: /discussion/*
 Disallow: /search
 Disallow: /music/artist/*
 Disallow: /music/album/*


### PR DESCRIPTION
Discussion threads are currently available under the url structure:

www.theguardian.com/discussion/<content short code>

This is causing issues for the bot, partly because this content doesn't exist on desktop and partly because we need to provide a sensible search context for this.

Therefore this changes robots.txt to hide the whole prefix from the bot for now.
