### PR TITLE
Disallow /print/ directory for indexation.

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -41,6 +41,7 @@ Disallow: /*/feedarticle/*
 Disallow: /travel/2013/aug/22/been-there-readers-competition?*
 Disallow: /preference/*
 Disallow: /59666047/
+Disallow: /print/
 
 User-agent: Mediapartners-Google 
 Disallow:


### PR DESCRIPTION
As you can see per [this query](https://www.google.co.uk/search?q=site:http://www.theguardian.com/print/&pws=0) Google is indexing our R1 print pages, and it shouldn't, as there's no furniture on that page. Since we have no way of redirecting it to the proper page, let's just block Googlebot from indexing it at all.
