### PR TITLE
Restores the specialised sitemaps on Joost's advice

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -46,3 +46,6 @@ Disallow: /info/tech-feedback
 
 User-agent: Mediapartners-Google
 Disallow:
+
+Sitemap: http://www.theguardian.com/newssitemap.xml
+Sitemap: http://www.theguardian.com/videositemap.xml


### PR DESCRIPTION
Video and News should work and be linked to in robots